### PR TITLE
[#34] 5.12. Structs [Closed]

### DIFF
--- a/src/doc/trpl/iterators.md
+++ b/src/doc/trpl/iterators.md
@@ -1,4 +1,4 @@
-% Iterators
+% イテレータ
 
 Let's talk about loops.
 

--- a/src/doc/trpl/iterators.md
+++ b/src/doc/trpl/iterators.md
@@ -55,7 +55,7 @@ for num in &nums {
 
 これには2つの理由があります。第一に、このほうが書き手の意味するところがはっきり表現できます。私たちはvectorのインデックスを作成してからその要素を繰り返し参照したいのではなく、vector自体を反復処理したいのです。第二に、このバージョンのほうがより効率的です: 1つ目の例では`num[i]`というようにインデックスを使っているため、余計な境界チェックが発生します。しかし、イテレータが順番にvectorの各要素の参照を生成していくため、2つ目の例では境界チェックが発生しません。これはイテレータにとってごく一般的な性質です: 私たちは不要な境界チェックを無視してもなお、安全であることを知っています。
 
-ここには`println!`の動作という、100%はっきりしていないもう1つの詳細があります。`num`は実際には`&i32`型です。これは`i32`の参照であり、`i32`それ自体ではありません。`println!`は私たちがそれを理解していなくとも、参照からうまく値を取り出してくれます。このコードも正しく動作します:
+ここには`println!`の動作という、100%はっきりしていないもう1つの詳細があります。`num`は実際には`&i32`型です。これは`i32`の参照であり、`i32`それ自体ではありません。`println!`は私たちがそのことを理解していなくとも、参照からうまく値を取り出してくれます。このコードも正しく動作します:
 
 ```rust
 let nums = vec![1, 2, 3];
@@ -65,7 +65,7 @@ for num in &nums {
 }
 ```
 
-今、私たちは明示的に`num`から参照を取り出しました。なぜ`&nums`は私たちに参照を渡すのでしょうか？第一に、`&`を用いて私たちが明示的に要求したからです。第二に、もしデータそれ自体を私たちに渡す場合、私たちはデータの所有者でなければならないため、データの複製と、それを私たちに渡す操作が伴います。参照を使えば、データの参照を借用し、参照を通すだけで、ムーブを行う必要がなくなります。
+今、私たちは明示的に`num`から参照を取り出しました。なぜ`&nums`は私たちに参照を渡すのでしょうか？第一に、`&`を用いて私たちが明示的に要求したからです。第二に、もしデータそれ自体を私たちに渡す場合、私たちはデータの所有者でなければならないため、データの複製と、それを私たちに渡す操作が伴います。参照を使えば、データの参照を借用し、参照を介するだけで、ムーブを行う必要がなくなります。
 
 そういうわけで、今やrangesはあまりあなたが欲しいものではなくなりました。それではあなたが代わりに欲しいと思うものについて話しましょう。
 
@@ -79,38 +79,27 @@ for num in &nums {
 
 ## コンシューマ
 
-A *consumer* operates on an iterator, returning some kind of value or values.
-The most common consumer is `collect()`. This code doesn't quite compile,
-but it shows the intention:
+コンシューマとはイテレータ上で動作し、1種類以上の値を返すものです。最も一般的なコンシューマは`collect()`です。このコードは全くコンパイルできませんが、意図するところは伝わるでしょう。
 
 ```{rust,ignore}
 let one_to_one_hundred = (1..101).collect();
 ```
 
-As you can see, we call `collect()` on our iterator. `collect()` takes
-as many values as the iterator will give it, and returns a collection
-of the results. So why won't this compile? Rust can't determine what
-type of things you want to collect, and so you need to let it know.
-Here's the version that does compile:
+ご覧のとおり、ここでイテレータが`collect()`を呼び出しています。`collect()`はイテレータが渡す沢山の値を受け取り、その結果をコレクションとして返します。それならなぜこのコードはコンパイルできないのでしょうか？Rustはあなたが集めたい値の型を判断することができないため、あなたが知っている型を指定する必要があります。こちらのバージョンはコンパイルできます:
 
 ```rust
 let one_to_one_hundred = (1..101).collect::<Vec<i32>>();
 ```
 
-If you remember, the `::<>` syntax allows us to give a type hint,
-and so we tell it that we want a vector of integers. You don't always
-need to use the whole type, though. Using a `_` will let you provide
-a partial hint:
+もしあなたが覚えているなら、`::<>`構文で型ヒントを与える事ができ、整数型のvectorが欲しいと伝えることができます。しかし、常に型をまるごとを書く必要はありません。`_`を用いることで部分的なヒントができます:
 
 ```rust
 let one_to_one_hundred = (1..101).collect::<Vec<_>>();
 ```
 
-This says "Collect into a `Vec<T>`, please, but infer what the `T` is for me."
-`_` is sometimes called a "type placeholder" for this reason.
+これは"値を`Vec<T>`の中に集めて下さい、しかし`T`は私のために推論して下さい"という意味です。このため`_`は度々"型プレースホルダー"と呼ばれています。
 
-`collect()` is the most common consumer, but there are others too. `find()`
-is one:
+`collect()`は最も有名なコンシューマですが、他にもあります。`find()`もそのひとつです:
 
 ```rust
 let greater_than_forty_two = (0..100)
@@ -122,57 +111,35 @@ match greater_than_forty_two {
 }
 ```
 
-`find` takes a closure, and works on a reference to each element of an
-iterator. This closure returns `true` if the element is the element we're
-looking for, and `false` otherwise. Because we might not find a matching
-element, `find` returns an `Option` rather than the element itself.
+`find`はクロージャを引数にとり、イテレータの各要素の参照で動作します。もし要素が私たちが期待するものであれば、このクロージャは`true`を返し、そうでなければ`false`を返します。要素がマッチングしないかもしれないため、`find`は要素それ自体ではなく`Option`を返します。
 
-Another important consumer is `fold`. Here's what it looks like:
+もう一つの重要なコンシューマは`fold`です。ここでは次のようになります:
 
 ```rust
 let sum = (1..4).fold(0, |sum, x| sum + x);
 ```
 
-`fold()` is a consumer that looks like this:
-`fold(base, |accumulator, element| ...)`. It takes two arguments: the first
-is an element called the *base*. The second is a closure that itself takes two
-arguments: the first is called the *accumulator*, and the second is an
-*element*. Upon each iteration, the closure is called, and the result is the
-value of the accumulator on the next iteration. On the first iteration, the
-base is the value of the accumulator.
+`fold()`はこのようなコンシューマです:`fold(base, |accumulator, element| ...)` 2つの引数を取ります: 第一引数は*base*と呼ばれます。第二引数は2つ引数を受け取るクロージャです:クロージャの第一引数は*accumulator*と呼ばれており、第二引数は*element*です。各反復毎にクロージャが呼び出され、その結果が次の反復のaccumulatorの値となります。反復処理の最初に、baseがaccumulatorの値となります。
 
-Okay, that's a bit confusing. Let's examine the values of all of these things
-in this iterator:
+ええ、少し混乱しますね。ではこのイテレータを以下の値で試してみましょう:
 
-| base | accumulator | element | closure result |
-|------|-------------|---------|----------------|
-| 0    | 0           | 1       | 1              |
-| 0    | 1           | 2       | 3              |
-| 0    | 3           | 3       | 6              |
+| base | accumulator | element | クロージャの結果 |
+|------|-------------|---------|------------------|
+| 0    | 0           | 1       | 1                |
+| 0    | 1           | 2       | 3                |
+| 0    | 3           | 3       | 6                |
 
-We called `fold()` with these arguments:
+これらの引数で`fold()`を呼び出してみました。
 
 ```rust
 # (1..4)
 .fold(0, |sum, x| sum + x);
 ```
 
-So, `0` is our base, `sum` is our accumulator, and `x` is our element.  On the
-first iteration, we set `sum` to `0`, and `x` is the first element of `nums`,
-`1`. We then add `sum` and `x`, which gives us `0 + 1 = 1`. On the second
-iteration, that value becomes our accumulator, `sum`, and the element is
-the second element of the array, `2`. `1 + 2 = 3`, and so that becomes
-the value of the accumulator for the last iteration. On that iteration,
-`x` is the last element, `3`, and `3 + 3 = 6`, which is our final
-result for our sum. `1 + 2 + 3 = 6`, and that's the result we got.
+というわけで、`0`がbaseで、`sum`がaccumulatorで、xがelementです。1度目の反復では、私たちはsumに0をセットし、`nums`の1つ目の要素`1`が`x`になります。私たちはそのとき`sum`と`x`を足し、`0 + 1 = 1`を計算します。2度目の反復では前回の`sum`がaccumulatorになり、elementは値の列の2番目の要素`2`になるため、`3 + 3 = 6`となり、これが最終的な結果となります。`1 + 2 + 3 = 6` が、得られる結果となります。
 
-Whew. `fold` can be a bit strange the first few times you see it, but once it
-clicks, you can use it all over the place. Any time you have a list of things,
-and you want a single result, `fold` is appropriate.
-
-Consumers are important due to one additional property of iterators we haven't
-talked about yet: laziness. Let's talk some more about iterators, and you'll
-see why consumers matter.
+ふぅ、ようやく説明し終わりました。`fold`は初めのうちこそ少し奇妙に見えるかもしれませんが、一度理解すればあらゆる場面で使えるでしょう。何かのリストを持っていて、そこから1つの結果を求めたいときならいつでも、`fold`は適切な処理です。
+コンシューマはまだ話していないイテレータのもう1つの性質のために重要な役割を担っています: 遅延性です。それではもっと詳しくイテレータについて話していきましょう、そうすればなぜコンシューマが重要なのか理解できるはずです。
 
 ## Iterators
 

--- a/src/doc/trpl/iterators.md
+++ b/src/doc/trpl/iterators.md
@@ -3,15 +3,14 @@
 ループの話をしましょう。
 
 Rustの`for`ループを覚えていますか？
-こちらが例です:
+こちらが例になります:
 ```rust
 for x in 0..10 {
     println!("{}", x);
 }
 ```
 今やあなたはRustに詳しいですから、私達はどのようにこの文が動いているのか詳しく話せます。
-Ranges(ここでは`0..10`)は'イテレータ'です。イテレータは繰り返し`.next()`メソッドを呼び出すことができ、データの連なりを与えてくれます。
-
+Range(ここでは`0..10`)は'イテレータ'です。イテレータは`.next()`メソッドを繰り返し呼び出すことができ、その都度順番に値を返すものです。
 こんな風に書いてみます:
 
 ```rust
@@ -31,9 +30,9 @@ rangeにイテレータをmutable束縛しています。`loop`の中の`match`�
 
 このコードは、基本的に`for`ループバージョンと同じ動作です。`for`ループはこの`loop`/`match`/`break`で構成された処理を手軽に書ける方法というわけです。
 
-しかしながら、`for`ループはイテレータのみに使うものではありません。`Iterator`トレイトを実装し組み込むことで、あなた自作のイテレータを書くこともできます。このガイドの範囲外ですが、Rustは多様な反復処理を実現するために便利なイテレータを幾つか提供しています。ただ、それらについて話す前に、Rustのアンチパターンについて話しておかなければなりません。しかもアンチパターンというのは、先ほど書いたようにrangesを使うことなのです。
+しかしながら、`for`ループはイテレータのみに使うものではありません。`Iterator`トレイトを実装し組み込むことで、あなた自作のイテレータを書くこともできます。このガイドの範囲外ですが、Rustは多様な反復処理を実現するために便利なイテレータを幾つか提供しています。ただ、それらについて話す前に、Rustのアンチパターンについて話しておかなければなりません。しかもアンチパターンというのは、先ほど書いたようにRangeを使うことなのです。
 
-ええ、確かに私たちはたった今rangesが如何にクールなのか話しました。しかしrangesは古典的過ぎます。例えば、もしあなたがvectorの中身を繰り返し処理したいとき、こんな風に書きたくなるかもしれません:
+ええ、確かに私たちはたった今Rangeが如何にクールなのか話しました。しかしRangeは古典的過ぎます。例えば、もしあなたがvectorの中身を繰り返し処理したいとき、こんな風に書きたくなるかもしれません:
 
 ```rust
 let nums = vec![1, 2, 3];
@@ -55,7 +54,7 @@ for num in &nums {
 
 これには2つの理由があります。第一に、このほうが書き手の意味するところがはっきり表現できます。私たちはvectorのインデックスを作成してからその要素を繰り返し参照したいのではなく、vector自体を反復処理したいのです。第二に、このバージョンのほうがより効率的です: 1つ目の例では`num[i]`というようにインデックスを使っているため、余計な境界チェックが発生します。しかし、イテレータが順番にvectorの各要素の参照を生成していくため、2つ目の例では境界チェックが発生しません。これはイテレータにとってごく一般的な性質です: 私たちは不要な境界チェックを無視してもなお、安全であることを知っています。
 
-ここには`println!`の動作という、100%はっきりしていないもう1つの詳細があります。`num`は実際には`&i32`型です。これは`i32`の参照であり、`i32`それ自体ではありません。`println!`は私たちがそのことを理解していなくとも、参照からうまく値を取り出してくれます。このコードも正しく動作します:
+ここには`println!`の動作という、詳細が100%はっきりしていないものがあります。`num`は実際には`&i32`型です。これは`i32`の参照であり、`i32`それ自体ではありません。`println!`は私たちがそのことを理解していなくとも、参照からうまく値を取り出してくれます。このコードも正しく動作します:
 
 ```rust
 let nums = vec![1, 2, 3];
@@ -67,7 +66,7 @@ for num in &nums {
 
 今、私たちは明示的に`num`から参照を取り出しました。なぜ`&nums`は私たちに参照を渡すのでしょうか？第一に、`&`を用いて私たちが明示的に要求したからです。第二に、もしデータそれ自体を私たちに渡す場合、私たちはデータの所有者でなければならないため、データの複製と、それを私たちに渡す操作が伴います。参照を使えば、データの参照を借用し、参照を介するだけで、ムーブを行う必要がなくなります。
 
-そういうわけで、今やrangesはあまりあなたが欲しいものではなくなりました。それではあなたが代わりに欲しいと思うものについて話しましょう。
+そういうわけで、今やRangeはあまりあなたが欲しいものではなくなりました。それではあなたが代わりに欲しいと思うものについて話しましょう。
 
 それは大きく分けて3つあり、これらに関係あるものです: イテレータ、*イテレータアダプタ*、そして*コンシューマ*。定義はこちら:
 
@@ -75,7 +74,7 @@ for num in &nums {
 * *イテレータアダプタ*はイテレータ上で動作し、出力の異なるイテレータを生成します。
 * *コンシューマ*はイテレータ上で動作し、幾つかの最終的な値の組を返します。
 
-あなたは既にイテレータとrangesを見てきたのですから、最初にコンシューマについて話しましょう。
+あなたは既にイテレータとRangeを見てきたのですから、最初にコンシューマについて話しましょう。
 
 ## コンシューマ
 
@@ -99,7 +98,7 @@ let one_to_one_hundred = (1..101).collect::<Vec<_>>();
 
 これは"値を`Vec<T>`の中に集めて下さい、しかし`T`は私のために推論して下さい"という意味です。このため`_`は度々"型プレースホルダー"と呼ばれています。
 
-`collect()`は最も有名なコンシューマですが、他にもあります。`find()`もそのひとつです:
+`collect()`は最も有名なコンシューマですが、他にもあります。`find()`はそのひとつです:
 
 ```rust
 let greater_than_forty_two = (0..100)
@@ -139,34 +138,23 @@ let sum = (1..4).fold(0, |sum, x| sum + x);
 というわけで、`0`がbaseで、`sum`がaccumulatorで、xがelementです。1度目の反復では、私たちはsumに0をセットし、`nums`の1つ目の要素`1`が`x`になります。私たちはそのとき`sum`と`x`を足し、`0 + 1 = 1`を計算します。2度目の反復では前回の`sum`がaccumulatorになり、elementは値の列の2番目の要素`2`になるため、`3 + 3 = 6`となり、これが最終的な結果となります。`1 + 2 + 3 = 6` が、得られる結果となります。
 
 ふぅ、ようやく説明し終わりました。`fold`は初めのうちこそ少し奇妙に見えるかもしれませんが、一度理解すればあらゆる場面で使えるでしょう。何かのリストを持っていて、そこから1つの結果を求めたいときならいつでも、`fold`は適切な処理です。
-コンシューマはまだ話していないイテレータのもう1つの性質のために重要な役割を担っています: 遅延性です。それではもっと詳しくイテレータについて話していきましょう、そうすればなぜコンシューマが重要なのか理解できるはずです。
+イテレータにはまだ話していないもう1つの性質の性質があり、コンシューマはそれに関連して重要な役割を担っています: 遅延性です。それではもっと詳しくイテレータについて話していきましょう、そうすればなぜコンシューマが重要なのか理解できるはずです。
 
 ## Iterators
 
-As we've said before, an iterator is something that we can call the
-`.next()` method on repeatedly, and it gives us a sequence of things.
-Because you need to call the method, this means that iterators
-can be *lazy* and not generate all of the values upfront. This code,
-for example, does not actually generate the numbers `1-100`, instead
-creating a value that merely represents the sequence:
+前に言ったように、イテレータは`.next()`メソッドを繰り返し呼び出すことができ、その都度順番に値を返すものです。メソッドを繰り返し呼ぶ必要があることから、イテレータは`lazy`であり、前もって全ての値を生成できないことがわかります。例えばこのコードでは、`1-100`の値は実際には生成されておらず、単にその代わりとなる値を生成しています:
 
 ```rust
 let nums = 1..100;
 ```
 
-Since we didn't do anything with the range, it didn't generate the sequence.
-Let's add the consumer:
+私たちはRangeを使っていないため、Rangeは値を生成しません。コンシューマを追加してみましょう:
 
 ```rust
 let nums = (1..100).collect::<Vec<i32>>();
 ```
 
-Now, `collect()` will require that the range gives it some numbers, and so
-it will do the work of generating the sequence.
-
-Ranges are one of two basic iterators that you'll see. The other is `iter()`.
-`iter()` can turn a vector into a simple iterator that gives you each element
-in turn:
+今、`collect()`は幾つかの値を渡してくれるRangeを要求し、値を生成する作業を行います。Rangeは基本的な2つのイテレータのうちの1つです。もう片方は`iter()`です。`iter()`はvectorを順番に各要素を渡してくれる単純なイテレータに変換できます:
 
 ```rust
 let nums = vec![1, 2, 3];
@@ -176,25 +164,19 @@ for num in nums.iter() {
 }
 ```
 
-These two basic iterators should serve you well. There are some more
-advanced iterators, including ones that are infinite.
+これら2つの基本的なイテレータはあなたの役に立つはずです。無限を扱えるものも含め、より応用的なイテレータも幾つか用意されています。
 
-That's enough about iterators. Iterator adapters are the last concept
-we need to talk about with regards to iterators. Let's get to it!
+これでイテレータについては十分でしょう。私たちがイテレータに関して最後に話しておくべき概念がイテレータアダプタです。それでは説明しましょう！
 
 ## Iterator adapters
 
-*Iterator adapters* take an iterator and modify it somehow, producing
-a new iterator. The simplest one is called `map`:
+*イテレータアダプタ*はイテレータを受け取って何らかの方法で加工し、新たなイテレータを生成します。`map`はその中でも最も単純なものです:
 
 ```{rust,ignore}
 (1..100).map(|x| x + 1);
 ```
 
-`map` is called upon another iterator, and produces a new iterator where each
-element reference has the closure it's been given as an argument called on it.
-So this would give us the numbers from `2-100`. Well, almost! If you
-compile the example, you'll get a warning:
+`map`は別のイテレータに呼び出され、各要素の参照をクロージャに引数として与えた結果を新しいイテレータとして生成します。つまりこのコードは私たちに`2-100`の値を返してくれるでしょう。えーっと、厳密には少し違います！もしこの例をコンパイルすると、こんな警告が出るはずです:
 
 ```text
 warning: unused result which must be used: iterator adaptors are lazy and
@@ -203,20 +185,15 @@ warning: unused result which must be used: iterator adaptors are lazy and
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
 
-Laziness strikes again! That closure will never execute. This example
-doesn't print any numbers:
+また遅延性にぶつかりました！このクロージャは実行されないですね。例えばこれは何の数字も出力されません:
 
 ```{rust,ignore}
 (1..100).map(|x| println!("{}", x));
 ```
 
-If you are trying to execute a closure on an iterator for its side effects,
-just use `for` instead.
+もし副作用のためにイテレータ上でクロージャの使用を試みるのであれば、代わりに`for`を使いましょう。
 
-There are tons of interesting iterator adapters. `take(n)` will return an
-iterator over the next `n` elements of the original iterator. Note that this
-has no side effect on the original iterator. Let's try it out with our infinite
-iterator from before:
+興味深いイテレータアダプタは沢山あります。`take(n)`は元のイテレータの`n`回目までを実行するイテレータを返します。これは元のイテレータに対して副作用を及ぼさないことに注意して下さい。では以前言っていた無限のイテレータを試してみましょう。
 
 ```rust
 # #![feature(step_by)]
@@ -225,7 +202,7 @@ for i in (1..).step_by(5).take(5) {
 }
 ```
 
-This will print
+これの出力は:
 
 ```text
 1
@@ -235,9 +212,7 @@ This will print
 21
 ```
 
-`filter()` is an adapter that takes a closure as an argument. This closure
-returns `true` or `false`. The new iterator `filter()` produces
-only the elements that that closure returns `true` for:
+`filter()`は引数としてクロージャをとるアダプタです。このクロージャは`true`か`false`を返します。`filter()`が生成する新たなイテレータはそのクロージャが`true`を返した要素のみとなります:
 
 ```rust
 for i in (1..100).filter(|&x| x % 2 == 0) {
@@ -245,14 +220,9 @@ for i in (1..100).filter(|&x| x % 2 == 0) {
 }
 ```
 
-This will print all of the even numbers between one and a hundred.
-(Note that because `filter` doesn't consume the elements that are
-being iterated over, it is passed a reference to each element, and
-thus the filter predicate uses the `&x` pattern to extract the integer
-itself.)
+これは1から100の間の偶数を全て出力します。(`filter`が反復処理をしてもイテレータを消費しないことに注目して下さい、そのためfilterは整数自体を取り出すため述語に`&x`パターンを使用しています。)
 
-You can chain all three things together: start with an iterator, adapt it
-a few times, and then consume the result. Check it out:
+あなたはここまでに説明された3つの概念を全て繋げることができます: イテレータから始まり、アダプタを少々、そして結果を消費といった感じです。これを見て下さい:
 
 ```rust
 (1..1000)
@@ -262,11 +232,6 @@ a few times, and then consume the result. Check it out:
     .collect::<Vec<i32>>();
 ```
 
-This will give you a vector containing `6`, `12`, `18`, `24`, and `30`.
+これは`6, 12, 18, 24,`そして`30`が入ったvectorがあなたに返されます。
 
-This is just a small taste of what iterators, iterator adapters, and consumers
-can help you with. There are a number of really useful iterators, and you can
-write your own as well. Iterators provide a safe, efficient way to manipulate
-all kinds of lists. They're a little unusual at first, but if you play with
-them, you'll get hooked. For a full list of the different iterators and
-consumers, check out the [iterator module documentation](../std/iter/index.html).
+イテレータ、イテレータアダプタ、そしてコンシューマがあなたの助けになることをほんの少しだけ体験できました。本当に便利なイテレータが幾つも用意されていますし、あなたがイテレータを自作することもできます。イテレータは全ての種類のリストに対し効率的な処理方法と安全性を提供します。これらは初めこそ珍しいかもしれませんが、もし使えばあなたは夢中になるでしょう。全てのイテレータとコンシューマのリストは[iterator module documentation](../std/iter/index.html)を参照して下さい。

--- a/src/doc/trpl/iterators.md
+++ b/src/doc/trpl/iterators.md
@@ -1,20 +1,18 @@
 % イテレータ
 
-Let's talk about loops.
+ループの話をしましょう。
 
-Remember Rust's `for` loop? Here's an example:
-
+Rustの`for`ループを覚えていますか？
+こちらが例です:
 ```rust
 for x in 0..10 {
     println!("{}", x);
 }
 ```
+今やあなたはRustに詳しいですから、私達はどのようにこの文が動いているのか詳しく話せます。
+Ranges(ここでは`0..10`)は'イテレータ'です。イテレータは繰り返し`.next()`メソッドを呼び出すことができ、データの連なりを与えてくれます。
 
-Now that you know more Rust, we can talk in detail about how this works.
-Ranges (the `0..10`) are 'iterators'. An iterator is something that we can
-call the `.next()` method on repeatedly, and it gives us a sequence of things.
-
-Like this:
+こんな風に書いてみます:
 
 ```rust
 let mut range = 0..10;
@@ -29,25 +27,13 @@ loop {
 }
 ```
 
-We make a mutable binding to the range, which is our iterator. We then `loop`,
-with an inner `match`. This `match` is used on the result of `range.next()`,
-which gives us a reference to the next value of the iterator. `next` returns an
-`Option<i32>`, in this case, which will be `Some(i32)` when we have a value and
-`None` once we run out. If we get `Some(i32)`, we print it out, and if we get
-`None`, we `break` out of the loop.
+rangeにイテレータをmutable束縛しています。`loop`の中の`match`は、イテレータである`range.next()`を呼び出すことで返ってくる次の値への参照を使用しています。`next`には`Option<i32>`が返ってきます。このケースでは、イテレータの次の値が返ってくればその値は`Some(i32)`であり、イテレータが尽きれば`None`が返ってきます。もし`Some(i32)`であればそれを表示し、`None`であれば`break`によりループから脱出しています。
 
-This code sample is basically the same as our `for` loop version. The `for`
-loop is just a handy way to write this `loop`/`match`/`break` construct.
+このコードは、基本的に`for`ループバージョンと同じ動作です。`for`ループはこの`loop`/`match`/`break`で構成された処理を手軽に書ける方法というわけです。
 
-`for` loops aren't the only thing that uses iterators, however. Writing your
-own iterator involves implementing the `Iterator` trait. While doing that is
-outside of the scope of this guide, Rust provides a number of useful iterators
-to accomplish various threads. Before we talk about those, we should talk about a
-Rust anti-pattern. And that's using ranges like this.
+しかしながら、`for`ループはイテレータのみに使うものではありません。`Iterator`トレイトを実装し組み込むことで、あなた自作のイテレータを書くこともできます。このガイドの範囲外ですが、Rustは多様な反復処理を実現するために便利なイテレータを幾つか提供しています。ただ、それらについて話す前に、Rustのアンチパターンについて話しておかなければなりません。しかもアンチパターンというのは、先ほど書いたようにrangesを使うことなのです。
 
-Yes, we just talked about how ranges are cool. But ranges are also very
-primitive. For example, if you needed to iterate over the contents of a vector,
-you may be tempted to write this:
+ええ、確かに私たちはたった今rangesが如何にクールなのか話しました。しかしrangesは古典的過ぎます。例えば、もしあなたがvectorの中身を繰り返し処理したいとき、こんな風に書きたくなるかもしれません:
 
 ```rust
 let nums = vec![1, 2, 3];
@@ -57,8 +43,7 @@ for i in 0..nums.len() {
 }
 ```
 
-This is strictly worse than using an actual iterator. You can iterate over vectors
-directly, so write this:
+これは実際のイテレータの使い方からすれば全く正しくありません。あなたはvectorを直接反復処理できるのですから、こう書くべきです:
 
 ```rust
 let nums = vec![1, 2, 3];
@@ -68,19 +53,9 @@ for num in &nums {
 }
 ```
 
-There are two reasons for this. First, this more directly expresses what we
-mean. We iterate through the entire vector, rather than iterating through
-indexes, and then indexing the vector. Second, this version is more efficient:
-the first version will have extra bounds checking because it used indexing,
-`nums[i]`. But since we yield a reference to each element of the vector in turn
-with the iterator, there's no bounds checking in the second example. This is
-very common with iterators: we can ignore unnecessary bounds checks, but still
-know that we're safe.
+これには2つの理由があります。第一に、このほうが書き手の意味するところがはっきり表現できます。私たちはvectorのインデックスを作成してからその要素を繰り返し参照したいのではなく、vector自体を反復処理したいのです。第二に、このバージョンのほうがより効率的です: 1つ目の例では`num[i]`というようにインデックスを使っているため、余計な境界チェックが発生します。しかし、イテレータが順番にvectorの各要素の参照を生成していくため、2つ目の例では境界チェックが発生しません。これはイテレータにとってごく一般的な性質です: 私たちは不要な境界チェックを無視してもなお、安全であることを知っています。
 
-There's another detail here that's not 100% clear because of how `println!`
-works. `num` is actually of type `&i32`. That is, it's a reference to an `i32`,
-not an `i32` itself. `println!` handles the dereferencing for us, so we don't
-see it. This code works fine too:
+ここには`println!`の動作という、100%はっきりしていないもう1つの詳細があります。`num`は実際には`&i32`型です。これは`i32`の参照であり、`i32`それ自体ではありません。`println!`は私たちがそれを理解していなくとも、参照からうまく値を取り出してくれます。このコードも正しく動作します:
 
 ```rust
 let nums = vec![1, 2, 3];
@@ -90,27 +65,19 @@ for num in &nums {
 }
 ```
 
-Now we're explicitly dereferencing `num`. Why does `&nums` give us
-references?  Firstly, because we explicitly asked it to with
-`&`. Secondly, if it gave us the data itself, we would have to be its
-owner, which would involve making a copy of the data and giving us the
-copy. With references, we're just borrowing a reference to the data,
-and so it's just passing a reference, without needing to do the move.
+今、私たちは明示的に`num`から参照を取り出しました。なぜ`&nums`は私たちに参照を渡すのでしょうか？第一に、`&`を用いて私たちが明示的に要求したからです。第二に、もしデータそれ自体を私たちに渡す場合、私たちはデータの所有者でなければならないため、データの複製と、それを私たちに渡す操作が伴います。参照を使えば、データの参照を借用し、参照を通すだけで、ムーブを行う必要がなくなります。
 
-So, now that we've established that ranges are often not what you want, let's
-talk about what you do want instead.
+そういうわけで、今やrangesはあまりあなたが欲しいものではなくなりました。それではあなたが代わりに欲しいと思うものについて話しましょう。
 
-There are three broad classes of things that are relevant here: iterators,
-*iterator adapters*, and *consumers*. Here's some definitions:
+それは大きく分けて3つあり、これらに関係あるものです: イテレータ、*イテレータアダプタ*、そして*コンシューマ*。定義はこちら:
 
-* *iterators* give you a sequence of values.
-* *iterator adapters* operate on an iterator, producing a new iterator with a
-  different output sequence.
-* *consumers* operate on an iterator, producing some final set of values.
+* *イテレータ*はあなたに値の列を渡します。
+* *イテレータアダプタ*はイテレータ上で動作し、出力の異なるイテレータを生成します。
+* *コンシューマ*はイテレータ上で動作し、幾つかの最終的な値の組を返します。
 
-Let's talk about consumers first, since you've already seen an iterator, ranges.
+あなたは既にイテレータとrangesを見てきたのですから、最初にコンシューマについて話しましょう。
 
-## Consumers
+## コンシューマ
 
 A *consumer* operates on an iterator, returning some kind of value or values.
 The most common consumer is `collect()`. This code doesn't quite compile,


### PR DESCRIPTION
暫定翻訳完了しました。
特に見ていただきたい点は、タプル構造体の部分ですね、ここ翻訳が怪しいところがちらほら有ります…
特に原文を引用すると、

> Now, we have actual names, rather than positions. Good names are important, and with a struct, we have actual names.

が恐らく「タプル構造体はフィールドの名前を持てないから位置で取り出したりするけど、名前付けはセマンティクス上重要だよね、だからフィールドに名前を付けられる通常の構造体のほうが良いよ」と言いたいと思われるんですが正直自信の無い憶測なので直訳にとどめました。
